### PR TITLE
Allow setting HTTP User-Agent per Nominatim usage policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ import net.dericbourg.nominatim.client.NominatimClient
 val client = NominatimClient.create()
 ```
 
+The [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim/)
+requires a valid HTTP `User-Agent` identifying your application. Set one explicitly:
+
+```kotlin
+val client = NominatimClient.create("MyApp/1.0 (contact@example.com)")
+```
+
+Alternatively, `NominatimClient.create()` reads the `NOMINATIM_USER_AGENT`
+environment variable if set, and otherwise falls back to a generic default.
+
 ### Perform a request
 
 ```kotlin

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,20 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Publishing requirements -->
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,24 @@
             <artifactId>converter-gson</artifactId>
             <version>${retrofit2.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.13.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>

--- a/src/main/kotlin/net/dericbourg/nominatim/client/NominatimClient.kt
+++ b/src/main/kotlin/net/dericbourg/nominatim/client/NominatimClient.kt
@@ -9,8 +9,29 @@ interface NominatimClient {
     fun search(request: SearchRequest): SearchResponse
 
     companion object {
+
+        private const val UserAgentEnvVar = "NOMINATIM_USER_AGENT"
+        private const val DefaultUserAgent = "nominatim-client (+https://github.com/adericbourg/nominatim-client)"
+
+        /**
+         * Creates a client using the `NOMINATIM_USER_AGENT` environment variable as
+         * the HTTP `User-Agent`, falling back to a default value if it is not set.
+         *
+         * The [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim/)
+         * requires a valid `User-Agent` identifying your application. Prefer
+         * [create] with an explicit value when possible.
+         */
         fun create(): NominatimClient {
-            return NominatimHttpClient()
+            val userAgent = System.getenv(UserAgentEnvVar) ?: DefaultUserAgent
+            return NominatimHttpClient(userAgent)
+        }
+
+        /**
+         * Creates a client using [userAgent] as the HTTP `User-Agent`, as required by the
+         * [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim/).
+         */
+        fun create(userAgent: String): NominatimClient {
+            return NominatimHttpClient(userAgent)
         }
     }
 }

--- a/src/main/kotlin/net/dericbourg/nominatim/client/NominatimHttpClient.kt
+++ b/src/main/kotlin/net/dericbourg/nominatim/client/NominatimHttpClient.kt
@@ -3,13 +3,13 @@ package net.dericbourg.nominatim.client
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class NominatimHttpClient : NominatimClient {
+class NominatimHttpClient(userAgent: String) : NominatimClient {
 
     companion object {
         val log: Logger = LoggerFactory.getLogger(this::class.java)
     }
 
-    private val api = NominatimRetrofitApi.nominatimRetrofitApi
+    private val api = NominatimRetrofitApi.create(userAgent)
 
     override fun search(request: SearchRequest): SearchResponse {
         val queryMap = if (request is QuerySearchRequest) {

--- a/src/main/kotlin/net/dericbourg/nominatim/client/NominatimRetrofitApi.kt
+++ b/src/main/kotlin/net/dericbourg/nominatim/client/NominatimRetrofitApi.kt
@@ -18,20 +18,24 @@ internal interface NominatimRetrofitApi {
 
         private const val BaseUrl = "https://nominatim.openstreetmap.org"
 
-        private val httpClient: OkHttpClient by lazy {
-            OkHttpClient.Builder().build()
-        }
+        internal fun create(userAgent: String, baseUrl: String = BaseUrl): NominatimRetrofitApi {
+            val httpClient = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    chain.proceed(
+                        chain.request().newBuilder()
+                            .header("User-Agent", userAgent)
+                            .build()
+                    )
+                }
+                .build()
 
-        private val retrofit: Retrofit by lazy {
-            Retrofit.Builder()
-                .baseUrl(BaseUrl)
+            val retrofit = Retrofit.Builder()
+                .baseUrl(baseUrl)
                 .addConverterFactory(GsonConverterFactory.create())
                 .client(httpClient)
                 .build()
-        }
 
-        internal val nominatimRetrofitApi: NominatimRetrofitApi by lazy {
-            retrofit.create(NominatimRetrofitApi::class.java)
+            return retrofit.create(NominatimRetrofitApi::class.java)
         }
     }
 }

--- a/src/test/kotlin/net/dericbourg/nominatim/client/NominatimUserAgentTest.kt
+++ b/src/test/kotlin/net/dericbourg/nominatim/client/NominatimUserAgentTest.kt
@@ -1,0 +1,36 @@
+package net.dericbourg.nominatim.client
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class NominatimUserAgentTest {
+
+    private lateinit var server: MockWebServer
+
+    @BeforeEach
+    fun startServer() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun stopServer() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `search sends the configured User-Agent header`() {
+        server.enqueue(MockResponse().setBody("[]"))
+
+        val userAgent = "acceptance-test-agent/1.0"
+        val api = NominatimRetrofitApi.create(userAgent, server.url("/").toString())
+        api.search(mapOf("q" to "tour eiffel")).execute()
+
+        val request = server.takeRequest()
+        assertEquals(userAgent, request.getHeader("User-Agent"))
+    }
+}


### PR DESCRIPTION
- Add `NominatimClient.create(userAgent)` overload plus a `NOMINATIM_USER_AGENT` environment-variable fallback and a built-in default, so requests carry a valid `User-Agent` as required by the [Nominatim Usage Policy](https://operations.osmfoundation.org/policies/nominatim/).
- Fix an unrelated but blocking build regression: `kotlin-maven-plugin`'s `compile`/`test-compile` goal bindings were dropped in `2b0ecb0` ("Cleanup local configuration"), so `mvn package` silently produced an empty jar (no compiled classes) for every build since. No release has shipped since that commit, so nothing broken reached Maven Central, but it needed fixing to get the test sources (and even the main sources) actually compiling.
- Add the repo's first automated test (JUnit 5 + OkHttp MockWebServer) asserting the configured `User-Agent` header reaches the outgoing request.
- Document the new option in the README.

Closes #51
